### PR TITLE
Add gate pass preview page for container orders

### DIFF
--- a/CSLSite/CSLSite.csproj
+++ b/CSLSite/CSLSite.csproj
@@ -224,6 +224,7 @@
     <Content Include="exportables\inventario_vhs.aspx" />
     <Content Include="pasepuertacontenedor\imprimirpasecontenedordespacho.aspx" />
     <Content Include="pasepuertacontenedor\ordenpuerta.aspx" />
+    <Content Include="pasepuertacontenedor\pase_puerta_orden_preview.aspx" />
     <Content Include="sav\turnosSavZAL.aspx" />
     <Content Include="sellos_imagenes\certificado_sellos_impo.aspx" />
     <Content Include="sellos_imagenes\consulta_certificado_sellos.aspx" />
@@ -2245,6 +2246,13 @@
     <Compile Include="pasepuertacontenedor\ordenpuerta.aspx.designer.cs">
       <DependentUpon>ordenpuerta.aspx</DependentUpon>
     </Compile>
+    <Compile Include="pasepuertacontenedor\pase_puerta_orden_preview.aspx.cs">
+      <DependentUpon>pase_puerta_orden_preview.aspx</DependentUpon>
+      <SubType>ASPXCodeBehind</SubType>
+    </Compile>
+    <Compile Include="pasepuertacontenedor\pase_puerta_orden_preview.aspx.designer.cs">
+      <DependentUpon>pase_puerta_orden_preview.aspx</DependentUpon>
+    </Compile>
     <Compile Include="sav\turnosSavZAL.aspx.cs">
       <DependentUpon>turnosSavZAL.aspx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>
@@ -3924,6 +3932,13 @@
     </Compile>
     <Compile Include="pasepuertacontenedor\imprimirpasecontenedordespacho.aspx.designer.cs">
       <DependentUpon>imprimirpasecontenedordespacho.aspx</DependentUpon>
+    </Compile>
+    <Compile Include="pasepuertacontenedor\pase_puerta_orden_preview.aspx.cs">
+      <DependentUpon>pase_puerta_orden_preview.aspx</DependentUpon>
+      <SubType>ASPXCodeBehind</SubType>
+    </Compile>
+    <Compile Include="pasepuertacontenedor\pase_puerta_orden_preview.aspx.designer.cs">
+      <DependentUpon>pase_puerta_orden_preview.aspx</DependentUpon>
     </Compile>
     <Compile Include="pasepuertacontenedor\listadopasescontenedor.aspx.cs">
       <DependentUpon>listadopasescontenedor.aspx</DependentUpon>

--- a/CSLSite/pasepuertacontenedor/ordenpuerta.aspx.cs
+++ b/CSLSite/pasepuertacontenedor/ordenpuerta.aspx.cs
@@ -281,6 +281,7 @@ namespace CSLSite
                 }
 
                 // Generar el e-Pass para cada contenedor seleccionado
+                long idPaseGenerado = 0;
                 foreach (var det in ContenedoresSeleccionados)
                 {
                     //Console.WriteLine($"Debug: NumeroContenedor = {det.NumeroContenedor}"); // Depuración
@@ -329,11 +330,13 @@ namespace CSLSite
                         Mostrar_Mensaje(r.MensajeProblema);
                         return;
                     }
+                    idPaseGenerado = r.Resultado;
                 }
                 string id_carga = Server.UrlEncode($"{ContenedoresSeleccionados.First().MRN}-{ContenedoresSeleccionados.First().MSN}-{ContenedoresSeleccionados.First().HSN}");
                 string link = $"<a href='../pasepuertacontenedor/imprimirpasecontenedordespacho.aspx?id_carga={id_carga}' target='_blank'>Imprimir Pase Puerta Despacho</a>";
+                string linkPreview = idPaseGenerado > 0 ? $"<a href='../pasepuertacontenedor/pase_puerta_orden_preview.aspx?id_pase={idPaseGenerado}' target='_blank'>Vista previa Pase Puerta</a>" : string.Empty;
 
-                Mostrar_Mensaje($"<b>Informativo! El pase fue generado con éxito. Para imprimirlo, haga clic en el siguiente enlace: {link}</b>");
+                Mostrar_Mensaje($"<b>Informativo! El pase fue generado con éxito. Para imprimirlo, haga clic en el siguiente enlace: {link} {linkPreview}</b>");
 
                 ContenedoresSeleccionados.Clear();
                 gvSeleccionados.DataSource = ContenedoresSeleccionados;

--- a/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx
+++ b/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx
@@ -1,0 +1,82 @@
+<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="pase_puerta_orden_preview.aspx.cs" Inherits="CSLSite.pase_puerta_orden_preview" %>
+<%@ Register assembly="Microsoft.ReportViewer.WebForms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" namespace="Microsoft.Reporting.WebForms" tagprefix="rsweb" %>
+<%@ Register Assembly="AjaxControlToolkit" Namespace="AjaxControlToolkit" TagPrefix="ajaxtoolkit" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head runat="server">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <title>Imprimir Pases de Puerta</title>
+
+    <link href="../img/favicon2.png" rel="icon"/>
+  <link href="../img/icono.png" rel="apple-touch-icon"/>
+ <!-- Bootstrap core CSS -->
+  <link href="../css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="../css/dashboard.css" rel="stylesheet"/>
+  <link href="../css/icons.css" rel="stylesheet"/>
+  <link href="../css/style.css" rel="stylesheet"/>
+
+    <style type="text/css">
+        .auto-style1 {
+            font-size: 11px;
+        }
+    </style>
+</head>
+<body>
+
+  <form id="FrmPase" runat="server" method="post" accept-charset="UTF-8" autocomplete="off"  >
+   <ajaxtoolkit:ToolkitScriptManager ID="tkajax" runat="server" EnableScriptGlobalization="true" CombineScripts="false" AsyncPostBackTimeout="500000" ScriptMode="Release">
+    </ajaxtoolkit:ToolkitScriptManager>
+
+     <div id="div_BrowserWindowName" style="visibility:hidden;">
+        <asp:HiddenField ID="hf_BrowserWindowName" runat="server" />
+  </div>
+ <div class="dashboard-container p-4" id="cuerpo" runat="server">
+     <div class="row">
+          <div class="col-md-12 d-flex justify-content-center">
+              <asp:UpdatePanel ID="UPMENSAJE" runat="server"  UpdateMode="Conditional" >
+                         <ContentTemplate>
+                             <div class="alert alert-warning" id="banmsg" runat="server" clientidmode="Static"><b>Error!</b> ...</div>
+                              </ContentTemplate>
+                        </asp:UpdatePanel>
+          </div>
+     </div>
+
+      <div class="row">
+             <div class="col-md-12 d-flex justify-content-center">
+
+                <asp:UpdatePanel ID="UPPASEPUERTA" runat="server" UpdateMode="Conditional" >
+                <ContentTemplate>
+                <div id="imagen" style="align-content:center;" runat="server" clientidmode="Static">
+                        <p align="center">
+                    <img src="../img/print_pase.png" width="350" height="450" alt ="" /></p>
+                </div>
+                <rsweb:ReportViewer ID="rwReporte" runat="server" Width="100%" Height="750px"
+                DocumentMapCollapsed="True" ShowDocumentMapButton="False"
+            ShowParameterPrompts="False" ShowPromptAreaButton="False">
+            <LocalReport EnableExternalImages="True" ReportPath="../reportes/rptpasepuerta.rdlc" >
+            </LocalReport>
+            </rsweb:ReportViewer>
+
+            </ContentTemplate>
+            </asp:UpdatePanel>
+
+       </div>
+        </div>
+      </div>
+
+    </form>
+
+
+
+</body>
+     <script type="text/javascript" src="../lib/datatables/datatables.min.js"></script>
+  <script type="text/javascript" src="../lib/advanced-datatable/js/DT_bootstrap.js"></script>
+
+   <script type="text/javascript" src="../lib/common-scripts.js"></script>
+
+   <script type="text/javascript" src="../lib/pages.js" ></script>
+
+   <script type="text/javascript" src="../lib/advanced-form-components.js"></script>
+</html>

--- a/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.cs
+++ b/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Configuration;
+using System.Data.SqlClient;
+using System.Net;
+using System.Net.Security;
+using System.Web;
+using BillionEntidades;
+using Microsoft.Reporting.WebForms;
+
+namespace CSLSite
+{
+    public partial class pase_puerta_orden_preview : System.Web.UI.Page
+    {
+        #region "Variables"
+        private long id_pase = 0;
+        #endregion
+
+        #region "Metodos del Reporte"
+        public Boolean inicializaReporte(String Reporte)
+        {
+            String wuser = Page.User.Identity.Name;
+            if (System.IO.File.Exists(Reporte) != true)
+            {
+                this.Mostrar_Mensaje(string.Format("<b>Informativo! </b>Reporte no existe"));
+                return false;
+            }
+
+            rwReporte.ProcessingMode = ProcessingMode.Local;
+            rwReporte.LocalReport.ReportPath = Reporte;
+            rwReporte.LocalReport.EnableExternalImages = true;
+            rwReporte.LocalReport.Refresh();
+            rwReporte.Visible = true;
+
+            return true;
+        }
+
+        public void AñadeDatasorurce(ReportDataSource wdatasourc)
+        {
+            rwReporte.LocalReport.DataSources.Clear();
+            rwReporte.LocalReport.DataSources.Add(wdatasourc);
+        }
+
+        public Boolean AcceptAllCertifications(Object sender, System.Security.Cryptography.X509Certificates.X509Certificate certification, System.Security.Cryptography.X509Certificates.X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            return true;
+        }
+        #endregion
+
+        #region "Metodos"
+        private void Actualiza_Paneles()
+        {
+            UPPASEPUERTA.Update();
+            UPMENSAJE.Update();
+        }
+
+        private void Mostrar_Mensaje(string Mensaje)
+        {
+            this.banmsg.Visible = true;
+            this.banmsg.InnerHtml = Mensaje;
+            this.Actualiza_Paneles();
+        }
+
+        private void Ocultar_Mensaje()
+        {
+            this.banmsg.InnerText = string.Empty;
+            this.banmsg.Visible = false;
+            this.Actualiza_Paneles();
+        }
+
+        private void Poblar_PasePuerta()
+        {
+            try
+            {
+                DataSet wdataset = new DataSet();
+                using (SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["midle"].ConnectionString))
+                using (SqlCommand cmd = new SqlCommand("[dbo].[lista_pase_despacho_por_idpase]", conn))
+                using (SqlDataAdapter da = new SqlDataAdapter(cmd))
+                {
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.AddWithValue("@id_pase", id_pase);
+                    da.Fill(wdataset);
+                }
+
+                if (wdataset.Tables.Count == 0 || wdataset.Tables[0].Rows.Count == 0)
+                {
+                    this.Mostrar_Mensaje(string.Format("<b>Error! </b>Lo sentimos, algo salió mal. Estamos trabajando para solucionarlo lo más pronto posible..no existen datos para emitir pase"));
+                    return;
+                }
+
+                ServicePointManager.ServerCertificateValidationCallback += AcceptAllCertifications;
+
+                string Reporte = "rptpasepuerta.rdlc";
+                Reporte = this.Server.MapPath(@"..\\reportes\\" + Reporte);
+                if (inicializaReporte(Reporte) != true)
+                {
+                    return;
+                }
+
+                ReportDataSource wdatasourc = new ReportDataSource("dsPasePuerta", wdataset.Tables[0]);
+                AñadeDatasorurce(wdatasourc);
+                rwReporte.LocalReport.Refresh();
+                this.rwReporte.Visible = true;
+                rwReporte.DataBind();
+                this.imagen.Visible = false;
+                this.Ocultar_Mensaje();
+            }
+            catch (Exception ex)
+            {
+                this.Mostrar_Mensaje(string.Format("<b>Error! </b>Lo sentimos, algo salió mal. Estamos trabajando para solucionarlo lo más pronto posible...{0}", ex.Message));
+            }
+        }
+        #endregion
+
+        protected override void OnInit(EventArgs e)
+        {
+            base.OnInit(e);
+            ViewStateUserKey = Session.SessionID;
+        }
+
+        protected void Page_Init(object sender, EventArgs e)
+        {
+            try
+            {
+                if (!Request.IsAuthenticated)
+                {
+                    Response.Redirect("../login.aspx", false);
+                    return;
+                }
+
+                if (!IsPostBack)
+                {
+                    this.banmsg.InnerText = string.Empty;
+
+                    string idParam = Request.QueryString["id_pase"];
+                    if (string.IsNullOrEmpty(idParam) || !long.TryParse(idParam, out id_pase))
+                    {
+                        this.Mostrar_Mensaje(string.Format("<b>Error! </b>Lo sentimos, algo salió mal. Estamos trabajando para solucionarlo lo más pronto posible..no existen datos para emitir pase"));
+                        return;
+                    }
+
+                    this.hf_BrowserWindowName.Value = id_pase.ToString();
+                    Poblar_PasePuerta();
+                }
+            }
+            catch (Exception ex)
+            {
+                this.Mostrar_Mensaje(string.Format("<b>Error! </b>Lo sentimos, algo salió mal. Estamos trabajando para solucionarlo lo más pronto posible...{0}", ex.Message));
+            }
+        }
+    }
+}

--- a/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.designer.cs
+++ b/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.designer.cs
@@ -1,0 +1,96 @@
+//------------------------------------------------------------------------------
+// <generado automáticamente>
+//     Este código fue generado por una herramienta.
+//
+//     Los cambios en este archivo podrían causar un comportamiento incorrecto y se perderán si
+//     se vuelve a generar el código.
+// </generado automáticamente>
+//------------------------------------------------------------------------------
+
+namespace CSLSite {
+
+
+    public partial class pase_puerta_orden_preview {
+        
+        /// <summary>
+        /// Control FrmPase.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlForm FrmPase;
+        
+        /// <summary>
+        /// Control tkajax.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::AjaxControlToolkit.ToolkitScriptManager tkajax;
+        
+        /// <summary>
+        /// Control hf_BrowserWindowName.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.HiddenField hf_BrowserWindowName;
+        
+        /// <summary>
+        /// Control cuerpo.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl cuerpo;
+        
+        /// <summary>
+        /// Control UPMENSAJE.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::System.Web.UI.UpdatePanel UPMENSAJE;
+        
+        /// <summary>
+        /// Control banmsg.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl banmsg;
+        
+        /// <summary>
+        /// Control UPPASEPUERTA.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::System.Web.UI.UpdatePanel UPPASEPUERTA;
+        
+        /// <summary>
+        /// Control imagen.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl imagen;
+        
+        /// <summary>
+        /// Control rwReporte.
+        /// </summary>
+        /// <remarks>
+        /// Campo generado automáticamente.
+        /// Para modificarlo, mueva la declaración del campo del archivo del diseñador al archivo de código subyacente.
+        /// </remarks>
+        protected global::Microsoft.Reporting.WebForms.ReportViewer rwReporte;
+    }
+}


### PR DESCRIPTION
## Summary
- Add pass preview page (`pase_puerta_orden_preview`) to display and print gate passes by ID
- Query database for pass data and render existing RDLC report with QR support
- Link preview page from order generation flow

## Testing
- `dotnet build CSLSite/CSLSite.csproj` *(fails: command not found)*
- `msbuild CSLSite/CSLSite.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc75d5bd48330866be2983d1e2c01