### PR TITLE
Add QR code support to pass preview

### DIFF
--- a/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.cs
+++ b/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.cs
@@ -98,8 +98,33 @@ namespace CSLSite
                     return;
                 }
 
-                ReportDataSource wdatasourc = new ReportDataSource("dsPasePuerta", wdataset.Tables[0]);
+                DataTable table = wdataset.Tables[0];
+                DataRow row = table.Rows[0];
+
+                object payload = null;
+                if (row.Table.Columns.Contains("CERTIFICADO_CODBARRA"))
+                {
+                    payload = row["CERTIFICADO_CODBARRA"];
+                }
+                else if (row.Table.Columns.Contains("NUMERO_PASE_N4"))
+                {
+                    payload = row["NUMERO_PASE_N4"];
+                }
+                else if (row.Table.Columns.Contains("PASE"))
+                {
+                    payload = row["PASE"];
+                }
+                else
+                {
+                    payload = id_pase.ToString();
+                }
+
+                string relQr = string.Format("~/barcode/handler/qr.ashx?data={0}", HttpUtility.UrlEncode(Convert.ToString(payload)));
+                string absQr = new Uri(Request.Url, ResolveUrl(relQr)).ToString();
+
+                ReportDataSource wdatasourc = new ReportDataSource("dsPasePuerta", table);
                 AñadeDatasorurce(wdatasourc);
+                rwReporte.LocalReport.SetParameters(new ReportParameter("QrUrl", absQr));
                 rwReporte.LocalReport.Refresh();
                 this.rwReporte.Visible = true;
                 rwReporte.DataBind();

--- a/CSLSite/pasepuertacontenedor/sql/alter_lista_pase_despacho_por_idpase.sql
+++ b/CSLSite/pasepuertacontenedor/sql/alter_lista_pase_despacho_por_idpase.sql
@@ -1,0 +1,44 @@
+ALTER PROCEDURE [dbo].[lista_pase_despacho_por_idpase]
+    @id_pase BIGINT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        pd.CONTAINER,
+        pd.MRN,
+        pd.MSN,
+        pd.HSN,
+        pd.BL,
+        pd.ITEM,
+        pd.SELLO1,
+        pd.SELLO2,
+        pd.ISO,
+        pd.NETO,
+        pd.BRUTO,
+        pd.LINE,
+        pd.RUC,
+        pd.EMPRESA,
+        pd.PROVINCIA,
+        pd.PLACA,
+        pd.LICENCIA,
+        pd.CONDUCTOR,
+        pd.TELEFONO,
+        pd.PASE,
+        pd.TTURNO,
+        pd.TINICIO,
+        pd.TFIN,
+        pd.DOCUMENTO,
+        pd.UBICACION,
+        pd.SELLO3,
+        pd.SELLO4,
+        pd.SELLOCGSA,
+        pd.BUQUE,
+        pd.IMPORTADOR,
+        pd.ADUANA,
+        pd.SN,
+        pd.CERTIFICADO_CODBARRA
+    FROM dbo.PASE_DESPACHO pd
+    WHERE pd.ID_PASE = @id_pase;
+END
+

--- a/CSLSite/reportes/rptpasepuerta.rdlc
+++ b/CSLSite/reportes/rptpasepuerta.rdlc
@@ -152,6 +152,12 @@
       </rd:DataSetInfo>
     </DataSet>
   </DataSets>
+  <ReportParameters>
+    <ReportParameter Name="QrUrl">
+      <DataType>String</DataType>
+      <AllowBlank>true</AllowBlank>
+    </ReportParameter>
+  </ReportParameters>
   <Body>
     <ReportItems>
       <Tablix Name="Tablix1">
@@ -1692,6 +1698,22 @@ iif(left(Fields!TTURNO.Value,7)="2021/02","","SU HORA MAXIMA DE LLEGADA A CALLE 
                           <Height>1.29674cm</Height>
                           <Width>3.70008cm</Width>
                           <ZIndex>3</ZIndex>
+                          <Style>
+                            <Border>
+                              <Style>None</Style>
+                            </Border>
+                          </Style>
+                        </Image>
+                        <Image Name="QrImage">
+                          <Source>External</Source>
+                          <Value>=Parameters!QrUrl.Value</Value>
+                          <MIMEType>image/png</MIMEType>
+                          <Sizing>Fit</Sizing>
+                          <Top>0cm</Top>
+                          <Left>11cm</Left>
+                          <Height>2cm</Height>
+                          <Width>2cm</Width>
+                          <ZIndex>4</ZIndex>
                           <Style>
                             <Border>
                               <Style>None</Style>


### PR DESCRIPTION
## Summary
- Generate absolute QR handler URL in pass preview and pass to report as parameter
- Render QR image in rptpasepuerta report using new parameter
- Include stored procedure update to expose CERTIFICADO_CODBARRA for QR payload

## Testing
- `dotnet build TerminalVitualS3.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bd4c88a4c8330bca42cfe16eaae86