### PR TITLE
Use field-based QR image for pass order preview

### DIFF
--- a/CSLSite/reportes/rptpasepuerta_orden.rdlc
+++ b/CSLSite/reportes/rptpasepuerta_orden.rdlc
@@ -140,6 +140,10 @@
           <DataField>SN</DataField>
           <rd:TypeName>System.String</rd:TypeName>
         </Field>
+        <Field Name="QR_URL">
+          <DataField>QR_URL</DataField>
+          <rd:TypeName>System.String</rd:TypeName>
+        </Field>
       </Fields>
       <Query>
         <DataSourceName>DummyDataSource</DataSourceName>
@@ -1712,7 +1716,7 @@ iif(left(Fields!TTURNO.Value,7)="2021/02","","SU HORA MAXIMA DE LLEGADA A CALLE 
                         </Image>
                         <Image Name="QrImage">
                           <Source>External</Source>
-                          <Value>=IIF(IsNothing(Parameters!QrUrl.Value) OR Parameters!QrUrl.Value = "", "about:blank", Parameters!QrUrl.Value)</Value>
+                          <Value>=Fields!QR_URL.Value</Value>
                           <MIMEType>image/png</MIMEType>
                           <Sizing>Fit</Sizing>
                           <Top>0cm</Top>


### PR DESCRIPTION
## Summary
- Populate QR_URL field in pass order preview data and remove parameter usage
- Load QR image from QR_URL dataset field in rptpasepuerta_orden.rdlc

## Testing
- `dotnet build CSLSite/CSLSite.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `msbuild CSLSite/CSLSite.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bfae466bc8330b12a4bcf93f2467f