### PR TITLE
Fix preview QR and header images for Pase Puerta report

### DIFF
--- a/CSLSite/reportes/rptpasepuerta_orden.rdlc
+++ b/CSLSite/reportes/rptpasepuerta_orden.rdlc
@@ -201,30 +201,32 @@
                                 <TablixCells>
                                   <TablixCell>
                                     <CellContents>
-                                      <Image Name="BarCode">
-                                        <Source>External</Source>
-                                        <Value>=code.VehicleImage(Fields!SN.Value,1)</Value>
-                                        <Sizing>Fit</Sizing>
-                                        <Style>
-                                          <Border>
-                                            <Style>None</Style>
-                                          </Border>
-                                        </Style>
-                                      </Image>
+                        <Image Name="BarCode">
+                          <Source>External</Source>
+                          <Value>=IIF(IsNothing(code.VehicleImage(Fields!SN.Value,1)) OR code.VehicleImage(Fields!SN.Value,1) = "", Nothing, code.VehicleImage(Fields!SN.Value,1))</Value>
+                          <MIMEType>image/png</MIMEType>
+                          <Sizing>Fit</Sizing>
+                          <Style>
+                            <Border>
+                              <Style>None</Style>
+                            </Border>
+                          </Style>
+                        </Image>
                                     </CellContents>
                                   </TablixCell>
                                   <TablixCell>
                                     <CellContents>
-                                      <Image Name="BarCode2">
-                                        <Source>External</Source>
-                                        <Value>=code.VehicleImage(Fields!SN.Value,2)</Value>
-                                        <Sizing>Fit</Sizing>
-                                        <Style>
-                                          <Border>
-                                            <Style>None</Style>
-                                          </Border>
-                                        </Style>
-                                      </Image>
+                        <Image Name="BarCode2">
+                          <Source>External</Source>
+                          <Value>=IIF(IsNothing(code.VehicleImage(Fields!SN.Value,2)) OR code.VehicleImage(Fields!SN.Value,2) = "", Nothing, code.VehicleImage(Fields!SN.Value,2))</Value>
+                          <MIMEType>image/png</MIMEType>
+                          <Sizing>Fit</Sizing>
+                          <Style>
+                            <Border>
+                              <Style>None</Style>
+                            </Border>
+                          </Style>
+                        </Image>
                                     </CellContents>
                                   </TablixCell>
                                 </TablixCells>
@@ -1716,7 +1718,7 @@ iif(left(Fields!TTURNO.Value,7)="2021/02","","SU HORA MAXIMA DE LLEGADA A CALLE 
                         </Image>
                         <Image Name="QrImage">
                           <Source>External</Source>
-                          <Value>=Fields!QR_URL.Value</Value>
+                          <Value>=IIF(IsNothing(Fields!QR_URL.Value) OR Fields!QR_URL.Value = "", Nothing, Fields!QR_URL.Value)</Value>
                           <MIMEType>image/png</MIMEType>
                           <Sizing>Fit</Sizing>
                           <Top>0cm</Top>


### PR DESCRIPTION
## Summary
- Validate external barcode and QR images in `rptpasepuerta_orden` RDLC and handle missing values
- Normalize QR_URL and reload ReportViewer datasource without parameters in Pase Puerta preview

## Testing
- `dotnet build CSLSite/CSLSite.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cad6b3e6c8330ade95345af47fb7c