### PR TITLE
feat: add report viewer binding for pase puerta

### DIFF
--- a/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.cs
+++ b/CSLSite/pasepuertacontenedor/pase_puerta_orden_preview.aspx.cs
@@ -134,6 +134,37 @@ namespace CSLSite
                 this.Mostrar_Mensaje(string.Format("<b>Error! </b>Lo sentimos, algo salió mal. Estamos trabajando para solucionarlo lo más pronto posible...{0}", ex.Message));
             }
         }
+
+        private void Poblar_PasePuerta_Orden(string numeroPase)
+        {
+            try
+            {
+                var table = new DataTable();
+
+                using (var cn = new SqlConnection(ConfigurationManager.ConnectionStrings["midle"].ConnectionString))
+                using (var cmd = new SqlCommand("vhs.SP_RPT_PasePuerta_Orden", cn))
+                using (var da = new SqlDataAdapter(cmd))
+                {
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("@NumeroPase", SqlDbType.VarChar).Value = numeroPase;
+                    da.Fill(table);
+                }
+
+                rwReporte.LocalReport.DataSources.Clear();
+                rwReporte.LocalReport.ReportPath = "reportes/rptpasepuerta_orden.rdlc";
+                rwReporte.LocalReport.DataSources.Add(new ReportDataSource("dsPasePuerta", table));
+                rwReporte.LocalReport.Refresh();
+
+                rwReporte.Visible = true;
+                rwReporte.DataBind();
+                imagen.Visible = false;
+                Ocultar_Mensaje();
+            }
+            catch (Exception ex)
+            {
+                this.Mostrar_Mensaje(string.Format("<b>Error! </b>Lo sentimos, algo salió mal. Estamos trabajando para solucionarlo lo más pronto posible...{0}", ex.Message));
+            }
+        }
         #endregion
 
         protected override void OnInit(EventArgs e)
@@ -155,6 +186,13 @@ namespace CSLSite
                 if (!IsPostBack)
                 {
                     this.banmsg.InnerText = string.Empty;
+
+                    string numeroPase = Request.QueryString["NumeroPase"];
+                    if (!string.IsNullOrEmpty(numeroPase))
+                    {
+                        Poblar_PasePuerta_Orden(numeroPase);
+                        return;
+                    }
 
                     string idParam = Request.QueryString["id_pase"];
                     if (string.IsNullOrEmpty(idParam) || !long.TryParse(idParam, out id_pase))


### PR DESCRIPTION
## Summary
- add method to populate `rptpasepuerta_orden` report with stored procedure `vhs.SP_RPT_PasePuerta_Orden`
- invoke new report population when `NumeroPase` query param is present

## Testing
- `dotnet build TerminalVitualS3.sln` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68b5da2904f8833098894280d4702785