### PR TITLE
Fix QR code image expression

### DIFF
--- a/CSLSite/reportes/rptpasepuerta_orden.rdlc
+++ b/CSLSite/reportes/rptpasepuerta_orden.rdlc
@@ -1718,7 +1718,7 @@ iif(left(Fields!TTURNO.Value,7)="2021/02","","SU HORA MAXIMA DE LLEGADA A CALLE 
                         </Image>
                         <Image Name="imgQRCode">
                           <Source>External</Source>
-                          <Value>=IIF(IsNothing(Fields!NumeroPase.Value) OR Fields!NumeroPase.Value = "", Nothing, "https://api.qrserver.com/v1/create-qr-code/?size=150x150&amp;data=" & Fields!NumeroPase.Value)</Value>
+                          <Value>IIf(IsNothing(Fields!NumeroPase.Value) OR Fields!NumeroPase.Value = "", Nothing, "https://api.qrserver.com/v1/create-qr-code/?size=150x150&amp;data=" &amp; Fields!NumeroPase.Value)</Value>
                           <MIMEType>image/png</MIMEType>
                           <Sizing>FitProportional</Sizing>
                           <Top>0.2in</Top>


### PR DESCRIPTION
## Summary
- fix QR code external image expression in rptpasepuerta_orden

## Testing
- `dotnet build CSLSite/CSLSite.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b71ccb05fc8330adb2b22381eb5b52